### PR TITLE
Force HTTPS to load the bookmarklet

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <meta property="og:title" content="2048 general AI solver for orignal game and clones"/>
   <meta property="og:site_name" content="2048 general AI solver for orignal game and clones"/>
   <meta property="og:description" content="2048 general AI solver for orignal game and clones"/>
-  <meta property="og:image" content="http://gabrielecirulli.github.io/2048/meta/og_image.png"/>
+  <meta property="og:image" content="https://gabrielecirulli.github.io/2048/meta/og_image.png"/>
   <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -26,7 +26,7 @@
   ga('send', 'pageview');
   var i=new Image().src="http://bob.quaji.com/ping.php?d=2048clones&u="+escape(document.location)+"&r="+escape(document.referrer);
   </script>
-  
+
 </head>
 <body>
   <div class="container">
@@ -35,7 +35,7 @@
     </div>
     <p class="game-intro">This is a general AI solver for the original 2048 game and many of its clones.</strong></p>
 	<br/>
-	<p class="game-explanation"><strong class="important">How to install:</strong> Drag this button to your bookmark bar and click it while in any game window. 
+	<p class="game-explanation"><strong class="important">How to install:</strong> Drag this button to your bookmark bar and click it while in any game window.
 
 	<a style="background-color: lightgrey;
     color: #000000;
@@ -48,28 +48,28 @@
     width: auto;
 	text-decoration: none;
 	border: 1px solid black;
-	" 
-	
-	onclick="alert('Please drag this link to your bookmarks bar.'); return false;" href="javascript:(function(){document.body.appendChild(document.createElement('script')).src='http://ronzil.github.io/2048AI-AllClones/2048AI-bookmarklet.js';})();">2048 AI</a>	
+	"
+
+	onclick="alert('Please drag this link to your bookmarks bar.'); return false;" href="javascript:(function(){document.body.appendChild(document.createElement('script')).src='https://ronzil.github.io/2048AI-AllClones/2048AI-bookmarklet.js';})();">2048 AI</a>
 	</p>
-	
+
 
     <p class="game-explanation">
       This AI has been tested on many 2048 variants such as:</br>
 	  <ul>
-		<li><a href="http://gabrielecirulli.github.io/2048/"> The original game</a><br/></li>
-		<li><a href="http://jmhummel.github.io/1597/"> Fibonacci variant</a><br/></li>
-		<li><a href="http://dweymouth.github.io/divideit/"> GCD variant</a><br/></li>
-		<li>and even <a href="http://rudradevbasak.github.io/16384_hex/"> the Hexagonal variant!</a><br/></li>
-	  </ul>	
-	  
+		<li><a href="https://gabrielecirulli.github.io/2048/"> The original game</a><br/></li>
+		<li><a href="https://jmhummel.github.io/1597/"> Fibonacci variant</a><br/></li>
+		<li><a href="https://dweymouth.github.io/divideit/"> GCD variant</a><br/></li>
+		<li>and even <a href="https://rudradevbasak.github.io/16384_hex/"> the Hexagonal variant!</a><br/></li>
+	  </ul>
+
 	  More variants and clones can be found at <a href=http://2048box.com/">2048box.com</a>
-		
+
     </p>
     <p class="game-explanation">
-	  For a detailed discussion about the AI <a href="http://stackoverflow.com/a/23853848/632039">see my post in StackOverflow.</a>
+	  For a detailed discussion about the AI <a href="https://stackoverflow.com/a/23853848/632039">see my post in StackOverflow.</a>
     </p>
-	
+
     <hr>
     <p>
     Original game by <a href="http://gabrielecirulli.com" target="_blank">Gabriele Cirulli</a>


### PR DESCRIPTION
From years, github.io force HTTPS by default (so the current version of the bookmarklet does not work on all the *.github.io 2048 clones)